### PR TITLE
chore: Add pull request format

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+##  What does this PR do
+
+
+##  Description of task to be completed
+
+
+##  How should this manually be tested
+
+
+##  What are the relevant Trello board stories
+
+
+##  Screenshots (If appropriate)
+
+
+##  Questions (If any): 


### PR DESCRIPTION
##  What does this PR do
Adds  a pull request format team members can use when raising when raising PR

##  Description of task to be completed
Make available uniform pull request.

##  How should this manually be tested
This can be tested after this PR has been merged. Any PR raised after should have the formats written out in the PR description box.

##  What are the relevant Trello board stories
[Delivers [chore-PR-format](https://trello.com/c/EGad7Bwy/27-as-a-developer-on-this-project-i-should-be-able-to-tell-what-a-pr-does-without-going-through-the-written-codes)]
