### PR TITLE
Added process.env.DB_ENV to variable dbEnv in dbConfig.js

### DIFF
--- a/data/dbConfig.js
+++ b/data/dbConfig.js
@@ -2,6 +2,6 @@ const knex = require('knex');
 
 const config = require('../knexfile.js');
 
-const dbEnv = process.env.DATABASE_URL || 'development';
+const dbEnv = process.env.DB_ENV || 'development';
 
 module.exports = knex(config[dbEnv]);


### PR DESCRIPTION
##  What does this PR do
This Pull Request changes the variable in dbConfig.js

##  Description of task to be completed
-add process.env.DB_ENV to variable dbEnv

##  What are the relevant Trello board stories
https://trello.com/c/vMDny8RS/82-bug-fix-wrong-environment-variable-used-in-dbconfigjs-file-should-be-dbenv