### PR TITLE
View Details of a Single Workout Plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ yarn.lock
 
 # ignore sqlite3 database
 *.db3
-index.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,5 @@ services:
 before_script:
   - psql -c 'create database befit_test;' -U postgres
   - psql -c "CREATE USER username WITH PASSWORD 'password';" -U postgres
-  - npx knex migrate:latest --env testing
-  - npx knex seed:run --env testing
 
 script: npm test

--- a/data/migrations/20190830093102_update-sets-table.js
+++ b/data/migrations/20190830093102_update-sets-table.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('sets', sets => {
+    sets.integer('position').unsigned();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('sets', sets => {
+    sets.dropColumn('position');
+  });
+};

--- a/data/seeds/04-add-predefined-workouts.js
+++ b/data/seeds/04-add-predefined-workouts.js
@@ -1,0 +1,38 @@
+exports.seed = function(knex) {
+  return knex('workouts')
+    .del()
+    .then(function() {
+      return knex('workouts').insert([
+        {
+          workout_name: 'Chest and Shoulder Smackdown',
+          workout_description: `Use this in place of your regular chest-and-delt workout if you're in lean-out mode. While it's more like a standard muscle-building training routine, you'll rev up the fat-burn a bit when you keep your rest periods under 30 seconds.`,
+          image_url:
+            'https://www.bodybuilding.com/images/2018/april/5-workous-that-are-insanely-efficient-at-torching-fat-signature-4-700xh.jpg',
+        },
+        {
+          workout_name: 'Full-Body Circuit',
+          workout_description: `This workout will get you moving in multiple directions. It's not about focusing on one body part, it's about getting everything moving and working together to burn calories while building up strength endurance.`,
+          image_url:
+            'https://www.bodybuilding.com/images/2018/april/5-workous-that-are-insanely-efficient-at-torching-fat-signature-2-700xh.jpg',
+        },
+        {
+          workout_name: 'Arm-Blast',
+          workout_description: `Biceps, triceps, and forearms are smaller body parts, but you can still bump up your metabolism if you're lifting hard and pushing on your rest periods. Keep your rest to 30-60 seconds between sets.`,
+          image_url:
+            'https://www.bodybuilding.com/images/2018/april/5-workous-that-are-insanely-efficient-at-torching-fat-signature-3-700xh.jpg',
+        },
+        {
+          workout_name: 'Back, Traps, And Core Routine',
+          workout_description: `The back and core work synergistically, making them a good, dynamic muscle pairing for a high-energy-burn weight-training session. This workout is front-loaded with four back-focused supersets. Then, you'll switch and do traps and abs in a superset to wrap it up.`,
+          image_url:
+            'https://www.bodybuilding.com/images/2018/april/5-workous-that-are-insanely-efficient-at-torching-fat-signature-1-700xh.jpg',
+        },
+        {
+          workout_name: 'Lower-Body Blast',
+          workout_description: `The glutes and hamstrings are often a trouble spot for women, but guys can benefit from this workout, too.`,
+          image_url:
+            'https://www.bodybuilding.com/exercises/exerciseImages/sequences/4361/Female/l/4361_2.jpg',
+        },
+      ]);
+    });
+};

--- a/data/seeds/05-add-exercises-to-workouts.js
+++ b/data/seeds/05-add-exercises-to-workouts.js
@@ -1,0 +1,207 @@
+const db = require('../dbConfig');
+
+exports.seed = function(knex) {
+  return knex('workouts-exercises')
+    .del()
+    .then(async function() {
+      const chestShoulder = await db('workouts')
+        .select('id')
+        .where('workout_name', '=', 'Chest and Shoulder Smackdown')
+        .first();
+      const fullBody = await db('workouts')
+        .select('id')
+        .where('workout_name', '=', 'Full-Body Circuit')
+        .first();
+      const armBlast = await db('workouts')
+        .select('id')
+        .where('workout_name', '=', 'Arm-Blast')
+        .first();
+      const backCore = await db('workouts')
+        .select('id')
+        .where('workout_name', '=', 'Back, Traps, And Core Routine')
+        .first();
+      const lowerBody = await db('workouts')
+        .select('id')
+        .where('workout_name', '=', 'Lower-Body Blast')
+        .first();
+      return knex('workouts-exercises').insert([
+        // Exercises for Chest and Shoulder Smackdown
+        {
+          exercise_id: 33,
+          workout_id: chestShoulder.id,
+        },
+        {
+          exercise_id: 4,
+          workout_id: chestShoulder.id,
+        },
+        {
+          exercise_id: 1,
+          workout_id: chestShoulder.id,
+        },
+        {
+          exercise_id: 665,
+          workout_id: chestShoulder.id,
+        },
+        {
+          exercise_id: 698,
+          workout_id: chestShoulder.id,
+        },
+        {
+          exercise_id: 706,
+          workout_id: chestShoulder.id,
+        },
+        // Exercises for Full Body Circuit
+        {
+          exercise_id: 282,
+          workout_id: fullBody.id,
+        },
+        {
+          exercise_id: 308,
+          workout_id: fullBody.id,
+        },
+        {
+          exercise_id: 447,
+          workout_id: fullBody.id,
+        },
+        {
+          exercise_id: 738,
+          workout_id: fullBody.id,
+        },
+        {
+          exercise_id: 337,
+          workout_id: fullBody.id,
+        },
+        {
+          exercise_id: 371,
+          workout_id: fullBody.id,
+        },
+        {
+          exercise_id: 315,
+          workout_id: fullBody.id,
+        },
+        {
+          exercise_id: 711,
+          workout_id: fullBody.id,
+        },
+        // Exercises for Arm Blast
+        {
+          exercise_id: 815,
+          workout_id: armBlast.id,
+        },
+        {
+          exercise_id: 575,
+          workout_id: armBlast.id,
+        },
+        {
+          exercise_id: 594,
+          workout_id: armBlast.id,
+        },
+        {
+          exercise_id: 836,
+          workout_id: armBlast.id,
+        },
+        {
+          exercise_id: 811,
+          workout_id: armBlast.id,
+        },
+        {
+          exercise_id: 579,
+          workout_id: armBlast.id,
+        },
+        {
+          exercise_id: 125,
+          workout_id: armBlast.id,
+        },
+        {
+          exercise_id: 838,
+          workout_id: armBlast.id,
+        },
+        {
+          exercise_id: 90,
+          workout_id: armBlast.id,
+        },
+        // Exercises for Back, Traps and Core Routine
+        {
+          exercise_id: 498,
+          workout_id: backCore.id,
+        },
+        {
+          exercise_id: 147,
+          workout_id: backCore.id,
+        },
+        {
+          exercise_id: 153,
+          workout_id: backCore.id,
+        },
+        {
+          exercise_id: 194,
+          workout_id: backCore.id,
+        },
+        {
+          exercise_id: 208,
+          workout_id: backCore.id,
+        },
+        {
+          exercise_id: 158,
+          workout_id: backCore.id,
+        },
+        {
+          exercise_id: 148,
+          workout_id: backCore.id,
+        },
+        {
+          exercise_id: 188,
+          workout_id: backCore.id,
+        },
+        {
+          exercise_id: 650,
+          workout_id: backCore.id,
+        },
+        {
+          exercise_id: 732,
+          workout_id: backCore.id,
+        },
+        {
+          exercise_id: 724,
+          workout_id: backCore.id,
+        },
+        // Exercises for Lower-Body Blast
+        {
+          exercise_id: 516,
+          workout_id: lowerBody.id,
+        },
+        {
+          exercise_id: 235,
+          workout_id: lowerBody.id,
+        },
+        {
+          exercise_id: 538,
+          workout_id: lowerBody.id,
+        },
+        {
+          exercise_id: 782,
+          workout_id: lowerBody.id,
+        },
+        {
+          exercise_id: 785,
+          workout_id: lowerBody.id,
+        },
+        {
+          exercise_id: 524,
+          workout_id: lowerBody.id,
+        },
+        {
+          exercise_id: 437,
+          workout_id: lowerBody.id,
+        },
+        {
+          exercise_id: 344,
+          workout_id: lowerBody.id,
+        },
+        {
+          exercise_id: 530,
+          workout_id: lowerBody.id,
+        },
+      ]);
+    });
+};

--- a/data/seeds/06-add-set-and-reps-to-exercises-in-workouts.js
+++ b/data/seeds/06-add-set-and-reps-to-exercises-in-workouts.js
@@ -1,0 +1,304 @@
+exports.seed = function(knex) {
+  // Deletes ALL existing entries
+  return knex('sets')
+    .del()
+    .then(function() {
+      // Inserts seed entries
+      return knex('sets').insert([
+        // Chest and Shoulder Smackdown 4-9
+        { workout_exercise_id: 4, reps: 10, position: 1 },
+        { workout_exercise_id: 4, reps: 8, position: 2 },
+        { workout_exercise_id: 4, reps: 8, position: 3 },
+        { workout_exercise_id: 4, reps: 6, position: 4 },
+
+        { workout_exercise_id: 5, reps: 12, position: 1 },
+        { workout_exercise_id: 5, reps: 12, position: 2 },
+        { workout_exercise_id: 5, reps: 10, position: 3 },
+        { workout_exercise_id: 5, reps: 10, position: 4 },
+
+        { workout_exercise_id: 6, reps: 12, position: 1 },
+        { workout_exercise_id: 6, reps: 11, position: 2 },
+        { workout_exercise_id: 6, reps: 10, position: 3 },
+
+        { workout_exercise_id: 7, reps: 8, position: 1 },
+        { workout_exercise_id: 7, reps: 8, position: 2 },
+        { workout_exercise_id: 7, reps: 8, position: 3 },
+
+        { workout_exercise_id: 8, reps: 10, position: 1 },
+        { workout_exercise_id: 8, reps: 10, position: 2 },
+        { workout_exercise_id: 8, reps: 10, position: 3 },
+
+        { workout_exercise_id: 9, reps: 10, position: 1 },
+        { workout_exercise_id: 9, reps: 10, position: 2 },
+        { workout_exercise_id: 9, reps: 10, position: 3 },
+
+        // Full-Body Circuit 10-17
+        { workout_exercise_id: 10, reps: 15, position: 1 },
+        { workout_exercise_id: 10, reps: 15, position: 2 },
+        { workout_exercise_id: 10, reps: 15, position: 3 },
+
+        { workout_exercise_id: 11, reps: 10, position: 1 },
+        { workout_exercise_id: 11, reps: 10, position: 2 },
+        { workout_exercise_id: 11, reps: 10, position: 3 },
+
+        { workout_exercise_id: 12, reps: 15, position: 1 },
+        { workout_exercise_id: 12, reps: 15, position: 1 },
+        { workout_exercise_id: 12, reps: 15, position: 1 },
+
+        { workout_exercise_id: 13, reps: 30, position: 1 },
+        { workout_exercise_id: 13, reps: 30, position: 1 },
+        { workout_exercise_id: 13, reps: 30, position: 1 },
+
+        {
+          workout_exercise_id: 14,
+          duration: '20 seconds',
+          position: 1,
+        },
+        {
+          workout_exercise_id: 14,
+          duration: '20 seconds',
+          position: 2,
+        },
+        {
+          workout_exercise_id: 14,
+          duration: '20 seconds',
+          position: 3,
+        },
+
+        { workout_exercise_id: 15, reps: 10, position: 1 },
+        { workout_exercise_id: 15, reps: 10, position: 2 },
+        { workout_exercise_id: 15, reps: 10, position: 3 },
+
+        { workout_exercise_id: 16, reps: 10, position: 1 },
+        { workout_exercise_id: 16, reps: 10, position: 2 },
+        { workout_exercise_id: 16, reps: 10, position: 3 },
+
+        {
+          workout_exercise_id: 17,
+          duration: '60 seconds',
+          position: 1,
+        },
+        {
+          workout_exercise_id: 17,
+          duration: '60 seconds',
+          position: 2,
+        },
+        {
+          workout_exercise_id: 17,
+          duration: '60 seconds',
+          position: 3,
+        },
+
+        // Arm-Blast
+        { workout_exercise_id: 18, reps: 12, position: 1 },
+        { workout_exercise_id: 18, reps: 10, position: 2 },
+        { workout_exercise_id: 18, reps: 8, position: 3 },
+        { workout_exercise_id: 18, reps: 6, position: 4 },
+        { workout_exercise_id: 18, reps: 4, position: 5 },
+
+        { workout_exercise_id: 19, reps: 12, position: 1 },
+        { workout_exercise_id: 19, reps: 10, position: 2 },
+        { workout_exercise_id: 19, reps: 8, position: 3 },
+        { workout_exercise_id: 19, reps: 6, position: 4 },
+        { workout_exercise_id: 19, reps: 4, position: 5 },
+
+        { workout_exercise_id: 20, reps: 15, position: 1 },
+        { workout_exercise_id: 20, reps: 15, position: 2 },
+        { workout_exercise_id: 20, reps: 15, position: 3 },
+        { workout_exercise_id: 20, reps: 15, position: 4 },
+        { workout_exercise_id: 20, reps: 15, position: 5 },
+
+        { workout_exercise_id: 21, reps: 15, position: 1 },
+        { workout_exercise_id: 21, reps: 15, position: 2 },
+        { workout_exercise_id: 21, reps: 15, position: 3 },
+        { workout_exercise_id: 21, reps: 15, position: 4 },
+        { workout_exercise_id: 21, reps: 15, position: 5 },
+
+        {
+          workout_exercise_id: 22,
+          duration: '12 seconds',
+          position: 1,
+        },
+        {
+          workout_exercise_id: 22,
+          duration: '12 seconds',
+          position: 2,
+        },
+        {
+          workout_exercise_id: 22,
+          duration: '12 seconds',
+          position: 3,
+        },
+        {
+          workout_exercise_id: 22,
+          duration: '12 seconds',
+          position: 4,
+        },
+        {
+          workout_exercise_id: 22,
+          duration: '12 seconds',
+          position: 5,
+        },
+
+        { workout_exercise_id: 23, reps: 12, position: 1 },
+        { workout_exercise_id: 23, reps: 12, position: 2 },
+        { workout_exercise_id: 23, reps: 12, position: 3 },
+        { workout_exercise_id: 23, reps: 12, position: 4 },
+        { workout_exercise_id: 23, reps: 12, position: 5 },
+
+        { workout_exercise_id: 24, reps: 8, position: 1 },
+        { workout_exercise_id: 24, reps: 8, position: 2 },
+        { workout_exercise_id: 24, reps: 8, position: 3 },
+        { workout_exercise_id: 24, reps: 8, position: 4 },
+        { workout_exercise_id: 24, reps: 8, position: 5 },
+
+        { workout_exercise_id: 25, reps: 10, position: 1 },
+        { workout_exercise_id: 25, reps: 10, position: 2 },
+        { workout_exercise_id: 25, reps: 10, position: 3 },
+        { workout_exercise_id: 25, reps: 10, position: 4 },
+        { workout_exercise_id: 25, reps: 10, position: 5 },
+
+        { workout_exercise_id: 26, reps: 0, position: 1 },
+        { workout_exercise_id: 26, reps: 0, position: 2 },
+        { workout_exercise_id: 26, reps: 0, position: 3 },
+        { workout_exercise_id: 26, reps: 0, position: 4 },
+        { workout_exercise_id: 26, reps: 0, position: 5 },
+
+        // Back, Traps, And Core Routine
+        { workout_exercise_id: 27, reps: 12, position: 1 },
+        { workout_exercise_id: 27, reps: 10, position: 2 },
+        { workout_exercise_id: 27, reps: 8, position: 3 },
+        { workout_exercise_id: 27, reps: 6, position: 4 },
+        { workout_exercise_id: 27, reps: 4, position: 5 },
+
+        { workout_exercise_id: 28, reps: 12, position: 1 },
+        { workout_exercise_id: 28, reps: 10, position: 2 },
+        { workout_exercise_id: 28, reps: 8, position: 3 },
+        { workout_exercise_id: 28, reps: 6, position: 4 },
+        { workout_exercise_id: 28, reps: 4, position: 5 },
+
+        { workout_exercise_id: 29, reps: 15, position: 1 },
+        { workout_exercise_id: 29, reps: 15, position: 2 },
+        { workout_exercise_id: 29, reps: 15, position: 3 },
+        { workout_exercise_id: 29, reps: 15, position: 4 },
+        { workout_exercise_id: 29, reps: 15, position: 5 },
+        {
+          workout_exercise_id: 30,
+          duration: '15 seconds',
+          position: 1,
+        },
+        {
+          workout_exercise_id: 30,
+          duration: '15 seconds',
+          position: 1,
+        },
+        {
+          workout_exercise_id: 30,
+          duration: '15 seconds',
+          position: 1,
+        },
+        {
+          workout_exercise_id: 30,
+          duration: '15 seconds',
+          position: 1,
+        },
+        {
+          workout_exercise_id: 30,
+          duration: '15 seconds',
+          position: 1,
+        },
+        { workout_exercise_id: 31, reps: 12, position: 1 },
+        { workout_exercise_id: 31, reps: 12, position: 2 },
+        { workout_exercise_id: 31, reps: 12, position: 3 },
+        { workout_exercise_id: 31, reps: 12, position: 4 },
+
+        { workout_exercise_id: 32, reps: 12, position: 1 },
+        { workout_exercise_id: 32, reps: 12, position: 2 },
+        { workout_exercise_id: 32, reps: 12, position: 3 },
+        { workout_exercise_id: 32, reps: 12, position: 4 },
+
+        { workout_exercise_id: 33, reps: 15, position: 1 },
+        { workout_exercise_id: 33, reps: 15, position: 2 },
+        { workout_exercise_id: 33, reps: 15, position: 3 },
+        { workout_exercise_id: 33, reps: 15, position: 4 },
+
+        { workout_exercise_id: 34, reps: 15, position: 1 },
+        { workout_exercise_id: 34, reps: 15, position: 2 },
+        { workout_exercise_id: 34, reps: 15, position: 3 },
+        { workout_exercise_id: 34, reps: 15, position: 4 },
+
+        { workout_exercise_id: 35, reps: 12, position: 1 },
+        { workout_exercise_id: 35, reps: 12, position: 2 },
+        { workout_exercise_id: 35, reps: 10, position: 3 },
+        { workout_exercise_id: 35, reps: 10, position: 4 },
+        { workout_exercise_id: 35, reps: 8, position: 5 },
+
+        { workout_exercise_id: 36, reps: 0, position: 1 },
+        { workout_exercise_id: 36, reps: 0, position: 2 },
+        { workout_exercise_id: 36, reps: 0, position: 3 },
+        { workout_exercise_id: 36, reps: 0, position: 4 },
+
+        { workout_exercise_id: 37, reps: 0, position: 1 },
+        { workout_exercise_id: 37, reps: 0, position: 2 },
+        { workout_exercise_id: 37, reps: 0, position: 3 },
+        { workout_exercise_id: 37, reps: 0, position: 4 },
+
+        // Lower-Body Blast
+        { workout_exercise_id: 38, reps: 12, position: 1 },
+        { workout_exercise_id: 38, reps: 11, position: 2 },
+        { workout_exercise_id: 38, reps: 10, position: 3 },
+
+        { workout_exercise_id: 39, reps: 12, position: 1 },
+        { workout_exercise_id: 39, reps: 11, position: 2 },
+        { workout_exercise_id: 39, reps: 10, position: 3 },
+
+        { workout_exercise_id: 40, reps: 10, position: 1 },
+        { workout_exercise_id: 40, reps: 10, position: 2 },
+        { workout_exercise_id: 40, reps: 10, position: 3 },
+        { workout_exercise_id: 40, reps: 10, position: 4 },
+
+        {
+          workout_exercise_id: 41,
+          duration: '8 seconds',
+          position: 1,
+        },
+        {
+          workout_exercise_id: 41,
+          duration: '8 seconds',
+          position: 2,
+        },
+        {
+          workout_exercise_id: 41,
+          duration: '8 seconds',
+          position: 3,
+        },
+        {
+          workout_exercise_id: 41,
+          duration: '8 seconds',
+          position: 4,
+        },
+
+        { workout_exercise_id: 42, reps: 12, position: 1 },
+        { workout_exercise_id: 42, reps: 12, position: 2 },
+        { workout_exercise_id: 42, reps: 12, position: 3 },
+        { workout_exercise_id: 42, reps: 12, position: 4 },
+
+        { workout_exercise_id: 43, reps: 10, position: 1 },
+        { workout_exercise_id: 43, reps: 10, position: 2 },
+        { workout_exercise_id: 43, reps: 10, position: 3 },
+        { workout_exercise_id: 43, reps: 10, position: 4 },
+
+        { workout_exercise_id: 44, reps: 10, position: 1 },
+        { workout_exercise_id: 44, reps: 10, position: 2 },
+        { workout_exercise_id: 44, reps: 10, position: 3 },
+
+        { workout_exercise_id: 45, reps: 10, position: 1 },
+        { workout_exercise_id: 45, reps: 10, position: 2 },
+        { workout_exercise_id: 45, reps: 10, position: 3 },
+
+        { workout_exercise_id: 46, reps: 8, position: 1 },
+        { workout_exercise_id: 46, reps: 8, position: 2 },
+        { workout_exercise_id: 46, reps: 8, position: 3 },
+      ]);
+    });
+};

--- a/middlewares/restrictedMiddleware.js
+++ b/middlewares/restrictedMiddleware.js
@@ -6,7 +6,7 @@ const secret = process.env.JWT_SECRET || 'default';
 module.exports = (req, res, next) => {
   const authHeader = req.get('Authorization');
   if (!authHeader) {
-    res.status(400).json({
+    return res.status(400).json({
       message: 'No Token Provided',
     });
   }
@@ -15,12 +15,12 @@ module.exports = (req, res, next) => {
   try {
     decodedToken = jwt.verify(token, secret);
   } catch (err) {
-    res.status(401).json({
-      message: 'Invalid Token.',
+    return res.status(401).json({
+      message: 'Invalid Token',
       err,
     });
   }
 
   req.userId = decodedToken.userId;
-  next();
+  return next();
 };

--- a/middlewares/validateId.js
+++ b/middlewares/validateId.js
@@ -1,0 +1,28 @@
+const workoutModel = require('../workouts/workoutsModels');
+
+async function validateId(req, res, next) {
+  const id = Number(req.params.id);
+  if (Number.isNaN(id) || id % 1 !== 0 || id < 0) {
+    return res.status(400).send({
+      error: 'Invalid Workout ID provided',
+    });
+  }
+  try {
+    const data = await workoutModel.findWorkoutExercises(id);
+    if (data) {
+      req.workoutDetails = data;
+      return next();
+    }
+    return res.status(404).send({
+      error: 'Workout ID provided does not exist',
+    });
+  } catch (error) {
+    console.log(error);
+    return res.status(500).send({
+      message: 'Internal Server Error',
+      error,
+    });
+  }
+}
+
+module.exports = validateId;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "node index.js",
     "server": "nodemon index.js",
+    "pretest": "npx knex migrate:latest --env testing && npx knex seed:run --env testing",
     "test": "cross-env DB_ENV=testing jest --verbose --forceExit"
   },
   "jest": {

--- a/workouts/workoutsController.js
+++ b/workouts/workoutsController.js
@@ -1,6 +1,5 @@
 const workoutModel = require('./workoutsModels.js');
 
-
 exports.getAllWorkout = async (req, res) => {
   try {
     const workouts = await workoutModel.getWorkouts();
@@ -9,5 +8,15 @@ exports.getAllWorkout = async (req, res) => {
     return res.status(500).json({
       Error: error,
     });
+  }
+};
+
+exports.getOneWorkout = async (req, res) => {
+  try {
+    res.status(200).json({
+      data: req.workoutDetails,
+    });
+  } catch (error) {
+    res.status(500).json({ error });
   }
 };

--- a/workouts/workoutsModels.js
+++ b/workouts/workoutsModels.js
@@ -1,10 +1,37 @@
 const db = require('../data/dbConfig');
 
-function getWorkoutExercises(id) {
-  return db('workouts-exercises')
-    .join('exercises', 'exercise_id', '=', 'exercises.id')
-    .join('workouts', 'workout_id', '=', 'workouts.id')
-    .where('workout_id', '=', id);
+function findWorkoutById(id) {
+  return db('workouts')
+    .where({ id })
+    .first()
+    .select('workout_name', 'workout_description', 'image_url');
+}
+
+async function findWorkoutExercises(id) {
+  const workout = await findWorkoutById(id);
+  if (workout)
+    workout.exercises = await db('workouts-exercises')
+      .join('exercises', 'exercise_id', '=', 'exercises.id')
+      .join('workouts', 'workout_id', '=', 'workouts.id')
+      .join(
+        'sets',
+        'workouts-exercises.id',
+        '=',
+        'workout_exercise_id',
+      )
+      .where('workout_id', '=', id)
+      .select(
+        'exercises.exercise_name',
+        'sets.reps',
+        'sets.duration',
+        'exercises.description',
+        'exercises.video',
+        'exercises.picture_one',
+        'exercises.picture_two',
+        'exercises.equipment',
+      )
+      .orderByRaw('position ASC');
+  return workout;
 }
 
 function getWorkouts() {
@@ -12,6 +39,7 @@ function getWorkouts() {
 }
 
 module.exports = {
+  findWorkoutExercises,
+  findWorkoutById,
   getWorkouts,
-  getWorkoutExercises,
 };

--- a/workouts/workoutsRoutes.js
+++ b/workouts/workoutsRoutes.js
@@ -1,18 +1,16 @@
 const express = require('express');
-
-const router = express.Router();
-const DB = require('./workoutsModels');
+const validateId = require('../middlewares/validateId');
 const workoutsController = require('./workoutsController');
 const checkLoggedIn = require('../middlewares/restrictedMiddleware');
 
-router.get('/:id', async (req, res) => {
-  try {
-    const exercises = await DB.getWorkoutExercises(req.params.id);
-    res.status(200).json(exercises);
-  } catch (error) {
-    res.status(404).json('Not found');
-  }
-});
+const router = express.Router();
+
+router.get(
+  '/:id',
+  checkLoggedIn,
+  validateId,
+  workoutsController.getOneWorkout,
+);
 
 router.get('/', checkLoggedIn, workoutsController.getAllWorkout);
 

--- a/workouts/workoutsTest.spec.js
+++ b/workouts/workoutsTest.spec.js
@@ -40,12 +40,59 @@ describe('Workouts', () => {
 
   describe('[/get] workouts', () => {
     it('should return 401 when invalid token is provided', () => {
-      token = 'mhvhgjbhjkljkn098765754667854565';
+      const invalidToken = 'mhvhgjbhjkljkn098765754667854565';
       return request(server)
         .get('/workouts')
-        .set('Authorization', `Bearer ${token}`)
+        .set('Authorization', `Bearer ${invalidToken}`)
         .then(res => {
           expect(res.statusCode).toBe(401);
+        });
+    });
+  });
+
+  describe('GET /workouts/:id - Get details of exercise in one workout plan', () => {
+    it('should return a status of 200 with the details of the workout', () => {
+      return request(server)
+        .get('/workouts/4')
+        .set('Authorization', `Bearer ${token}`)
+        .then(res => {
+          expect(res.statusCode).toBe(200);
+          expect(res.body.data).toBeDefined();
+        });
+    });
+    it('should return a status of 400 if workout id is invalid', () => {
+      return request(server)
+        .get('/workouts/4ty')
+        .set('Authorization', `Bearer ${token}`)
+        .then(res => {
+          expect(res.statusCode).toBe(400);
+          expect(res.body.error).toBeDefined();
+        });
+    });
+    it('should return a status of 404 if workout id does not exist', () => {
+      return request(server)
+        .get('/workouts/4000000')
+        .set('Authorization', `Bearer ${token}`)
+        .then(res => {
+          expect(res.statusCode).toBe(404);
+          expect(res.body.error).toBeDefined();
+        });
+    });
+    it('should return a status of 401 if invalid token', () => {
+      const invalidToken = 'mhvhgjbhjkljkn098765754667854565';
+      return request(server)
+        .get('/workouts/4')
+        .set('Authorization', `Bearer ${invalidToken}`)
+        .then(res => {
+          expect(res.statusCode).toBe(401);
+        });
+    });
+    it('should return a status of 400 if no token is provided', () => {
+      return request(server)
+        .get('/workouts/4')
+        .then(res => {
+          expect(res.statusCode).toBe(400);
+          expect(res.body.message).toBeDefined();
         });
     });
   });


### PR DESCRIPTION
##  What does this PR do
This PR enables logged in users to get the details of a single workout plan

##  Description of tasks to be completed
seed predefined workouts
seed exercises to workouts
seed sets table with workouts' exercises details
add middleware to validate workout id
add function to fetch workout details from database
add controller function
add the controller and the middleware to the router
write tests to test for getOneWorkout endpoint

##  How should this manually be tested
- clone this repository
- checkout `ft-view-single-workout` branch
- run `yarn run dev` or `npm run dev`
- run 
```
  - npx knex migrate:latest
  - npx knex seed:run
```
- signup using by sending a `post` request to `/auth/signup` with the following credentials 
```
{
  username: "testUser",
  email: "user@email.com",
  password: "password"
}
```
- use the token provided to send a get request to `/workouts/{id}` to test this changes

##  What are the relevant Trello board stories
[As a User I want to be able to View a Specific Workout](https://trello.com/c/tGk2VXQ1/57-as-a-user-i-want-to-be-able-to-view-a-specific-workoutsingle-workout)
