### PR TITLE
fix: login controller waits for bcrypt to compare before next block

### DIFF
--- a/users/usersControllers.js
+++ b/users/usersControllers.js
@@ -42,7 +42,8 @@ exports.login = async (req, res) => {
         .json({ message: 'Oops, email is required for login.' });
     }
     const user = await User.findBy({ email });
-    if (user && bcrypt.compare(password, user.password)) {
+    const isEqual = await bcrypt.compare(password, userPassword)
+    if (user && isEqual) {
       return res.status(200).json({
         token: generateToken(user.email, user.id),
         userId: user.id,


### PR DESCRIPTION
##  What does this PR do
fixed bug where an existing user could login by not providing a password.

##  What are the relevant Trello board stories
https://trello.com/c/DZbdytco/152-bug-ensure-bcrypt-compares-password-on-login
